### PR TITLE
Simplify & optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Measuring temperature with a thermistor and the 12-bit ADC, transmitting it with
 an RFM radio module, powering off the thermistor, putting the radio module in 
 sleep mode and going to power down sleep mode including disabling digital input 
 buffer on all pins in between measurements & transmissions, resulting in idle 
-power consumption of about 4 µA including ADC, USART, SPI and the radio module.  
+power consumption of about 2 µA (4 µA with USB to serial bridge connected to PC).  
 Using RTC's periodic interrupt timer to periodically wake up the controller.
 Also using the event system for nothing useful at all, just to see how it works 😀
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Measuring temperature with a thermistor and the 12-bit ADC, transmitting it with
 an RFM radio module, powering off the thermistor, putting the radio module in 
 sleep mode and going to power down sleep mode including disabling digital input 
 buffer on all pins in between measurements & transmissions, resulting in idle 
-power consumption of about 5 µA including ADC, USART, SPI and the radio module.  
+power consumption of about 4 µA including ADC, USART, SPI and the radio module.  
 Using RTC's periodic interrupt timer to periodically wake up the controller.
 Also using the event system for nothing useful at all, just to see how it works 😀
 


### PR DESCRIPTION
- disabling pin interrupts before sleep not necessary
- disabling input buffer on MISO pin before sleep saves up to 40 µA in sleep mode
- measure and transmit each 8 seconds
- enable pullup on MISO pin instead of disabling input buffer